### PR TITLE
YARN-11133. YarnClient gets the wrong EffectiveMinCapacity value

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/records/impl/pb/QueueConfigurationsPBImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/records/impl/pb/QueueConfigurationsPBImpl.java
@@ -72,11 +72,11 @@ public class QueueConfigurationsPBImpl extends QueueConfigurations {
           .setEffectiveMaxCapacity(convertToProtoFormat(this.effMaxResource));
     }
     if (this.configuredMinResource != null) {
-      builder.setEffectiveMinCapacity(
+      builder.setConfiguredMinCapacity(
           convertToProtoFormat(this.configuredMinResource));
     }
     if (this.configuredMaxResource != null) {
-      builder.setEffectiveMaxCapacity(
+      builder.setConfiguredMaxCapacity(
           convertToProtoFormat(this.configuredMaxResource));
     }
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
It calls the QueueConfigurations#getEffectiveMinCapacity to get the wrong value when I use the YarnClient. I found some bugs with QueueConfigurationsPBImpl#mergeLocalToBuilder. ConfiguredMinResource was incorrectly assigned to effMinResource. This causes the real effMinResource to be overwritten and configuredMinResource is null. 
JIRA: YARN-11133

### How was this patch tested?
Test in a production environment

### For code changes:
Call the correct method

